### PR TITLE
Implement SparkColumnarFileReader for Datasource integration with Lance

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieLanceRecordIterator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieLanceRecordIterator.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.io.storage;
+
+import com.lancedb.lance.file.LanceFileReader;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.UnsafeProjection;
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.apache.spark.sql.vectorized.LanceArrowColumnVector;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * Shared iterator implementation for reading Lance files and converting Arrow batches to Spark rows.
+ * This iterator is used by both Hudi's internal Lance reader and Spark datasource integration.
+ *
+ * <p>The iterator manages the lifecycle of:
+ * <ul>
+ *   <li>BufferAllocator - Arrow memory management</li>
+ *   <li>LanceFileReader - Lance file handle</li>
+ *   <li>ArrowReader - Arrow batch reader</li>
+ *   <li>ColumnarBatch - Current batch being iterated</li>
+ * </ul>
+ *
+ * <p>Records are converted to {@link UnsafeRow} using {@link UnsafeProjection} for efficient
+ * serialization and memory management.
+ */
+public class HoodieLanceRecordIterator implements ClosableIterator<UnsafeRow> {
+  private final BufferAllocator allocator;
+  private final LanceFileReader lanceReader;
+  private final ArrowReader arrowReader;
+  private final StructType schema;
+  private final UnsafeProjection projection;
+  private final String path;
+
+  private ColumnarBatch currentBatch;
+  private Iterator<InternalRow> rowIterator;
+  private boolean closed = false;
+
+  /**
+   * Creates a new Lance record iterator.
+   *
+   * @param allocator Arrow buffer allocator for memory management
+   * @param lanceReader Lance file reader
+   * @param arrowReader Arrow reader for batch reading
+   * @param schema Spark schema for the records
+   * @param path File path (for error messages)
+   */
+  public HoodieLanceRecordIterator(BufferAllocator allocator,
+                                   LanceFileReader lanceReader,
+                                   ArrowReader arrowReader,
+                                   StructType schema,
+                                   String path) {
+    this.allocator = allocator;
+    this.lanceReader = lanceReader;
+    this.arrowReader = arrowReader;
+    this.schema = schema;
+    this.projection = UnsafeProjection.create(schema);
+    this.path = path;
+  }
+
+  @Override
+  public boolean hasNext() {
+    // If we have records in current batch, return true
+    if (rowIterator != null && rowIterator.hasNext()) {
+      return true;
+    }
+
+    // Close previous batch before loading next
+    if (currentBatch != null) {
+      currentBatch.close();
+      currentBatch = null;
+    }
+
+    // Try to load next batch
+    try {
+      if (arrowReader.loadNextBatch()) {
+        VectorSchemaRoot root = arrowReader.getVectorSchemaRoot();
+
+        // Wrap each Arrow FieldVector in LanceArrowColumnVector for type-safe access
+        ColumnVector[] columns = root.getFieldVectors().stream()
+                .map(LanceArrowColumnVector::new)
+                .toArray(ColumnVector[]::new);
+
+        // Create ColumnarBatch and keep it alive while iterating
+        currentBatch = new ColumnarBatch(columns, root.getRowCount());
+        rowIterator = currentBatch.rowIterator();
+        return rowIterator.hasNext();
+      }
+    } catch (IOException e) {
+      throw new HoodieException("Failed to read next batch from Lance file: " + path, e);
+    }
+
+    return false;
+  }
+
+  @Override
+  public UnsafeRow next() {
+    if (!hasNext()) {
+      throw new IllegalStateException("No more records available");
+    }
+    InternalRow row = rowIterator.next();
+    // Convert to UnsafeRow immediately while batch is still open
+    return projection.apply(row);
+  }
+
+  @Override
+  public void close() {
+    // Make close() idempotent - safe to call multiple times
+    if (closed) {
+      return;
+    }
+    closed = true;
+
+    IOException arrowException = null;
+    Exception lanceException = null;
+
+    // Close current batch if exists
+    if (currentBatch != null) {
+      currentBatch.close();
+      currentBatch = null;
+    }
+
+    // Close Arrow reader
+    if (arrowReader != null) {
+      try {
+        arrowReader.close();
+      } catch (IOException e) {
+        arrowException = e;
+      }
+    }
+
+    // Close Lance reader
+    if (lanceReader != null) {
+      try {
+        lanceReader.close();
+      } catch (Exception e) {
+        lanceException = e;
+      }
+    }
+
+    // Always close allocator
+    if (allocator != null) {
+      allocator.close();
+    }
+
+    // Throw any exceptions that occurred
+    if (arrowException != null) {
+      throw new HoodieIOException("Failed to close Arrow reader", arrowException);
+    }
+    if (lanceException != null) {
+      throw new HoodieException("Failed to close Lance reader", lanceException);
+    }
+  }
+}

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkFileWriterFactory.java
@@ -106,6 +106,15 @@ public class HoodieSparkFileWriterFactory extends HoodieFileWriterFactory {
     throw new HoodieIOException("Not support write to Orc file");
   }
 
+  @Override
+  protected HoodieFileWriter newLanceFileWriter(String instantTime, StoragePath path, HoodieConfig config, Schema schema,
+                                                TaskContextSupplier taskContextSupplier) throws IOException {
+    boolean populateMetaFields = config.getBooleanOrDefault(HoodieTableConfig.POPULATE_META_FIELDS);
+    StructType structType = HoodieInternalRowUtils.getCachedSchema(schema);
+
+    return new HoodieSparkLanceWriter(path, structType, instantTime, taskContextSupplier, storage, populateMetaFields);
+  }
+
   private static HoodieRowParquetWriteSupport getHoodieRowParquetWriteSupport(StorageConfiguration<?> conf, Schema schema,
                                                                               HoodieConfig config, boolean enableBloomFilter) {
     Option<BloomFilter> filter = enableBloomFilter ? Option.of(createBloomFilter(config)) : Option.empty();

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceReader.java
@@ -21,7 +21,6 @@ package org.apache.hudi.io.storage;
 import com.lancedb.lance.file.LanceFileReader;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.hudi.HoodieSchemaConversionUtils;
 import org.apache.hudi.common.bloom.BloomFilter;
@@ -37,19 +36,14 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.catalyst.expressions.UnsafeProjection;
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.LanceArrowUtils;
-import org.apache.spark.sql.vectorized.ColumnVector;
-import org.apache.spark.sql.vectorized.ColumnarBatch;
-import org.apache.spark.sql.vectorized.LanceArrowColumnVector;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -144,7 +138,7 @@ public class HoodieSparkLanceReader implements HoodieSparkFileReader {
 
       ArrowReader arrowReader = lanceReader.readAll(null, null, DEFAULT_BATCH_SIZE);
 
-      return new LanceRecordIterator(allocator, lanceReader, arrowReader, sparkSchema);
+      return new HoodieLanceRecordIterator(allocator, lanceReader, arrowReader, sparkSchema, path.toString());
     } catch (Exception e) {
       allocator.close();
       throw new HoodieException("Failed to create Lance reader for: " + path, e);
@@ -177,7 +171,7 @@ public class HoodieSparkLanceReader implements HoodieSparkFileReader {
       // Read only the requested columns from Lance file for efficiency
       ArrowReader arrowReader = lanceReader.readAll(columnNames, null, DEFAULT_BATCH_SIZE);
 
-      return new LanceRecordIterator(allocator, lanceReader, arrowReader, requestedSparkSchema);
+      return new HoodieLanceRecordIterator(allocator, lanceReader, arrowReader, requestedSparkSchema, path.toString());
     } catch (Exception e) {
       allocator.close();
       throw new HoodieException("Failed to create Lance reader for: " + path, e);
@@ -209,118 +203,6 @@ public class HoodieSparkLanceReader implements HoodieSparkFileReader {
       return reader.numRows();
     } catch (Exception e) {
       throw new HoodieException("Failed to get row count from Lance file: " + path, e);
-    }
-  }
-
-  /**
-   * Iterator implementation that reads Lance file batches and converts to UnsafeRows.
-   * Keeps ColumnarBatch alive while iterating to avoid unnecessary data copying.
-   */
-  private class LanceRecordIterator implements ClosableIterator<UnsafeRow> {
-    private final BufferAllocator allocator;
-    private final LanceFileReader lanceReader;
-    private final ArrowReader arrowReader;
-    private final StructType schema;
-    private final UnsafeProjection projection;
-    private ColumnarBatch currentBatch;
-    private Iterator<InternalRow> rowIterator;
-
-    public LanceRecordIterator(BufferAllocator allocator,
-                               LanceFileReader lanceReader,
-                               ArrowReader arrowReader,
-                               StructType schema) {
-      this.allocator = allocator;
-      this.lanceReader = lanceReader;
-      this.arrowReader = arrowReader;
-      this.schema = schema;
-      this.projection = UnsafeProjection.create(schema);
-    }
-
-    @Override
-    public boolean hasNext() {
-      // If we have records in current batch, return true
-      if (rowIterator != null && rowIterator.hasNext()) {
-        return true;
-      }
-
-      // Close previous batch before loading next
-      if (currentBatch != null) {
-        currentBatch.close();
-        currentBatch = null;
-      }
-
-      // Try to load next batch
-      try {
-        if (arrowReader.loadNextBatch()) {
-          VectorSchemaRoot root = arrowReader.getVectorSchemaRoot();
-
-          // Wrap each Arrow FieldVector in LanceArrowColumnVector for type-safe access
-          ColumnVector[] columns = root.getFieldVectors().stream()
-                  .map(LanceArrowColumnVector::new)
-                  .toArray(ColumnVector[]::new);
-
-          // Create ColumnarBatch and keep it alive while iterating
-          currentBatch = new ColumnarBatch(columns, root.getRowCount());
-          rowIterator = currentBatch.rowIterator();
-          return rowIterator.hasNext();
-        }
-      } catch (IOException e) {
-        throw new HoodieException("Failed to read next batch from Lance file: " + path, e);
-      }
-
-      return false;
-    }
-
-    @Override
-    public UnsafeRow next() {
-      if (!hasNext()) {
-        throw new IllegalStateException("No more records available");
-      }
-      InternalRow row = rowIterator.next();
-      // Convert to UnsafeRow immediately while batch is still open
-      return projection.apply(row);
-    }
-
-    @Override
-    public void close() {
-      IOException arrowException = null;
-      Exception lanceException = null;
-
-      // Close current batch if exists
-      if (currentBatch != null) {
-        currentBatch.close();
-      }
-
-      // Close Arrow reader
-      if (arrowReader != null) {
-        try {
-          arrowReader.close();
-        } catch (IOException e) {
-          arrowException = e;
-        }
-      }
-
-      // Close Lance reader
-      if (lanceReader != null) {
-        try {
-          lanceReader.close();
-        } catch (Exception e) {
-          lanceException = e;
-        }
-      }
-
-      // Always close allocator
-      if (allocator != null) {
-        allocator.close();
-      }
-
-      // Throw any exceptions that occurred
-      if (arrowException != null) {
-        throw new HoodieIOException("Failed to close Arrow reader", arrowException);
-      }
-      if (lanceException != null) {
-        throw new HoodieException("Failed to close Lance reader", lanceException);
-      }
     }
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRecordContext.java
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/BaseSparkInternalRecordContext.java
@@ -216,7 +216,7 @@ public abstract class BaseSparkInternalRecordContext extends RecordContext<Inter
     if (internalRow instanceof UnsafeRow) {
       return internalRow;
     }
-    final UnsafeProjection unsafeProjection = HoodieInternalRowUtils.getCachedUnsafeProjection(schema.toAvroSchema());
+    final UnsafeProjection unsafeProjection = HoodieInternalRowUtils.getCachedUnsafeProjection(schema);
     return unsafeProjection.apply(internalRow);
   }
 

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieInternalRowUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieInternalRowUtils.scala
@@ -18,11 +18,11 @@
 
 package org.apache.spark.sql
 
+import org.apache.avro.Schema
 import org.apache.hudi.AvroConversionUtils.convertAvroSchemaToStructType
 import org.apache.hudi.avro.HoodieAvroUtils.{createFullName, toJavaDate}
 import org.apache.hudi.exception.HoodieException
-
-import org.apache.avro.Schema
+import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.spark.sql.HoodieCatalystExpressionUtils.generateUnsafeProjection
 import org.apache.spark.sql.HoodieUnsafeRowUtils.{NestedFieldPath, composeNestedFieldPath}
 import org.apache.spark.sql.catalyst.expressions.{SpecificInternalRow, UnsafeArrayData, UnsafeProjection, UnsafeRow}
@@ -35,7 +35,6 @@ import org.apache.spark.unsafe.types.UTF8String
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.{Supplier, Function => JFunction}
 import java.util.{ArrayDeque => JArrayDeque, Collections => JCollections, Deque => JDeque, Map => JMap}
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -84,9 +83,9 @@ object HoodieInternalRowUtils {
   /**
    * Provides cached instance of [[UnsafeProjection]] to project Java object based [[InternalRow]] to [[UnsafeRow]].
    */
-  def getCachedUnsafeProjection(schema: Schema): UnsafeProjection = {
+  def getCachedUnsafeProjection(schema: HoodieSchema): UnsafeProjection = {
     identicalUnsafeProjectionThreadLocal.get()
-      .getOrElseUpdate(schema, UnsafeProjection.create(getCachedSchema(schema)))
+      .getOrElseUpdate(schema.getAvroSchema, UnsafeProjection.create(getCachedSchema(schema.getAvroSchema)))
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
@@ -216,6 +216,20 @@ trait SparkAdapter extends Serializable {
                           dataSchema: StructType): SparkColumnarFileReader
 
   /**
+   * Get Lance file reader
+   *
+   * @param vectorized true if vectorized reading is not prohibited due to schema, reading mode, etc
+   * @param sqlConf    the [[SQLConf]] used for the read
+   * @param options    passed as a param to the file format
+   * @param hadoopConf some configs will be set for the hadoopConf
+   * @return Lance file reader
+   */
+  def createLanceFileReader(vectorized: Boolean,
+                            sqlConf: SQLConf,
+                            options: Map[String, String],
+                            hadoopConf: Configuration): SparkColumnarFileReader
+
+  /**
    * use new qe execute
    */
   def sqlExecutionWithNewExecutionId[T](sparkSession: SparkSession,

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
@@ -49,7 +49,11 @@ public enum HoodieFileFormat {
       + "way to store Hive data. It was designed to overcome limitations of the other Hive file "
       + "formats. Using ORC files improves performance when Hive is reading, writing, and "
       + "processing data.")
-  ORC(".orc");
+  ORC(".orc"),
+
+  @EnumFieldDescription("Lance is a modern columnar data format optimized for ML and AI workloads. "
+      + "It provides efficient random access, versioning, and integration with Apache Arrow.")
+  LANCE(".lance");
 
   public static final Set<String> BASE_FILE_EXTENSIONS = Arrays.stream(HoodieFileFormat.values())
       .map(HoodieFileFormat::getFileExtension)

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
@@ -112,7 +112,7 @@ public class HoodieFileWriterFactory {
   }
 
   protected HoodieFileWriter newLanceFileWriter(
-      String instantTime, StoragePath path, HoodieConfig config, Schema schema,
+      String instantTime, StoragePath path, HoodieConfig config, HoodieSchema schema,
       TaskContextSupplier taskContextSupplier) throws IOException {
     throw new UnsupportedOperationException();
   }

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import static org.apache.hudi.common.model.HoodieFileFormat.HFILE;
+import static org.apache.hudi.common.model.HoodieFileFormat.LANCE;
 import static org.apache.hudi.common.model.HoodieFileFormat.ORC;
 import static org.apache.hudi.common.model.HoodieFileFormat.PARQUET;
 
@@ -71,6 +72,9 @@ public class HoodieFileWriterFactory {
     if (ORC.getFileExtension().equals(extension)) {
       return newOrcFileWriter(instantTime, path, config, schema, taskContextSupplier);
     }
+    if (LANCE.getFileExtension().equals(extension)) {
+      return newLanceFileWriter(instantTime, path, config, schema, taskContextSupplier);
+    }
     throw new UnsupportedOperationException(extension + " format not supported yet.");
   }
 
@@ -103,6 +107,12 @@ public class HoodieFileWriterFactory {
 
   protected HoodieFileWriter newOrcFileWriter(
       String instantTime, StoragePath path, HoodieConfig config, HoodieSchema schema,
+      TaskContextSupplier taskContextSupplier) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  protected HoodieFileWriter newLanceFileWriter(
+      String instantTime, StoragePath path, HoodieConfig config, Schema schema,
       TaskContextSupplier taskContextSupplier) throws IOException {
     throw new UnsupportedOperationException();
   }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
@@ -27,6 +27,7 @@ import org.apache.hudi.storage.StorageConfiguration
 import com.lancedb.lance.file.LanceFileReader
 import org.apache.arrow.memory.RootAllocator
 import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.schema.MessageType
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.JoinedRow
@@ -66,7 +67,8 @@ class SparkLanceReaderBase(enableVectorizedReader: Boolean) extends SparkColumna
                     partitionSchema: StructType,
                     internalSchemaOpt: util.Option[InternalSchema],
                     filters: Seq[Filter],
-                    storageConf: StorageConfiguration[Configuration]): Iterator[InternalRow] = {
+                    storageConf: StorageConfiguration[Configuration],
+                    tableSchemaOpt: util.Option[MessageType] = util.Option.empty()): Iterator[InternalRow] = {
 
     val filePath = file.filePath.toString
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.lance
+
+import org.apache.hudi.common.util
+import org.apache.hudi.internal.schema.InternalSchema
+import org.apache.hudi.io.storage.HoodieLanceRecordIterator
+import org.apache.hudi.storage.StorageConfiguration
+
+import com.lancedb.lance.file.LanceFileReader
+import org.apache.arrow.memory.RootAllocator
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.TaskContext
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.JoinedRow
+import org.apache.spark.sql.execution.datasources.{PartitionedFile, SparkColumnarFileReader}
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.LanceArrowUtils
+
+import java.io.IOException
+
+import scala.collection.JavaConverters._
+
+/**
+ * Reader for Lance files in Spark datasource.
+ * Implements vectorized reading using LanceArrowColumnVector.
+ *
+ * @param enableVectorizedReader whether to use vectorized reading (currently always true for Lance)
+ */
+class SparkLanceReaderBase(enableVectorizedReader: Boolean) extends SparkColumnarFileReader {
+
+  // Batch size for reading Lance files (number of rows per batch)
+  private val DEFAULT_BATCH_SIZE = 512
+
+  /**
+   * Read a Lance file with schema projection and partition column support.
+   *
+   * @param file              Lance file to read
+   * @param requiredSchema    desired output schema of the data (columns to read)
+   * @param partitionSchema   schema of the partition columns. Partition values will be appended to the end of every row
+   * @param internalSchemaOpt option of internal schema for schema.on.read (not currently used for Lance)
+   * @param filters           filters for data skipping. Not guaranteed to be used; the spark plan will also apply the filters.
+   * @param storageConf       the hadoop conf
+   * @return iterator of rows read from the file output type says [[InternalRow]] but could be [[ColumnarBatch]]
+   */
+  override def read(file: PartitionedFile,
+                    requiredSchema: StructType,
+                    partitionSchema: StructType,
+                    internalSchemaOpt: util.Option[InternalSchema],
+                    filters: Seq[Filter],
+                    storageConf: StorageConfiguration[Configuration]): Iterator[InternalRow] = {
+
+    val filePath = file.filePath.toString
+
+    if (requiredSchema.isEmpty && partitionSchema.isEmpty) {
+      // No columns requested - return empty iterator
+      Iterator.empty
+    } else {
+      // Create Arrow allocator for reading
+      val allocator = new RootAllocator(Long.MaxValue)
+
+      try {
+        // Open Lance file reader
+        val lanceReader = LanceFileReader.open(filePath, allocator)
+
+        // Extract column names from required schema for projection
+        val columnNames: java.util.List[String] = if (requiredSchema.nonEmpty) {
+          requiredSchema.fields.map(_.name).toList.asJava
+        } else {
+          // If only partition columns requested, read minimal data
+          null
+        }
+
+        // Get schema from Lance file for HoodieLanceRecordIterator
+        val arrowSchema = lanceReader.schema()
+        val sparkSchema = LanceArrowUtils.fromArrowSchema(arrowSchema)
+
+        // Read data with column projection (filters not supported yet)
+        val arrowReader = lanceReader.readAll(columnNames, null, DEFAULT_BATCH_SIZE)
+
+        // Create iterator using shared HoodieLanceRecordIterator
+        val lanceIterator = new HoodieLanceRecordIterator(
+          allocator,
+          lanceReader,
+          arrowReader,
+          if (requiredSchema.nonEmpty) requiredSchema else sparkSchema,
+          filePath
+        )
+
+        // Register cleanup listener with Spark task context
+        Option(TaskContext.get()).foreach(
+          _.addTaskCompletionListener[Unit](_ => lanceIterator.close())
+        )
+
+        // Need to convert to scala iterator for proper reading
+        val iter = lanceIterator.asScala
+
+        // Handle partition columns
+        if (partitionSchema.length == 0) {
+          // No partition columns - return rows directly
+          iter.asInstanceOf[Iterator[InternalRow]]
+        } else {
+          // Append partition values to each row using JoinedRow
+          val joinedRow = new JoinedRow()
+          iter.map(row => joinedRow(row, file.partitionValues))
+        }
+
+      } catch {
+        case e: Exception =>
+          allocator.close()
+          throw new IOException(s"Failed to read Lance file: $filePath", e)
+      }
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.functional
+
+import org.apache.hudi.DataSourceWriteOptions._
+import org.apache.hudi.DefaultSparkRecordMerger
+import org.apache.hudi.common.table.HoodieTableConfig
+import org.apache.hudi.config.HoodieWriteConfig
+import org.apache.hudi.testutils.HoodieSparkClientTestBase
+
+import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.junit.jupiter.api.Assertions.assertEquals
+
+/**
+ * Basic functional tests for Lance file format with Hudi Spark datasource.
+ */
+class TestLanceDataSource extends HoodieSparkClientTestBase {
+
+  var spark: SparkSession = _
+
+  @BeforeEach
+  override def setUp(): Unit = {
+    super.setUp()
+    spark = sqlContext.sparkSession
+  }
+
+  @AfterEach
+  override def tearDown(): Unit = {
+    super.tearDown()
+    spark = null
+  }
+
+  @Test
+  def testBasicWriteAndRead(): Unit = {
+    val tableName = "test_lance_table"
+    val tablePath = s"$basePath/$tableName"
+
+    // Create test data
+    val records = Seq(
+      (1, "Alice", 30, 95.5),
+      (2, "Bob", 25, 87.3),
+      (3, "Charlie", 35, 92.1)
+    )
+    val df = spark.createDataFrame(records).toDF("id", "name", "age", "score")
+
+    // Write to Hudi table with Lance base file format
+    df.write
+      .format("hudi")
+      .option(HoodieTableConfig.BASE_FILE_FORMAT.key(), "LANCE")
+      .option(RECORDKEY_FIELD.key(), "id")
+      .option(PRECOMBINE_FIELD.key(), "age")
+      .option(TABLE_NAME.key(), tableName)
+      .option(HoodieWriteConfig.TBL_NAME.key(), tableName)
+      .option(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key(), classOf[DefaultSparkRecordMerger].getName)
+      .mode(SaveMode.Overwrite)
+      .save(tablePath)
+
+    // Read back and verify
+  val readDf = spark.read
+      .format("hudi")
+      .load(tablePath)
+
+    val result = readDf.select("id", "name", "age", "score")
+      .orderBy("id")
+      .collect()
+
+    assertEquals(3, result.length, "Should read 3 records")
+    assertEquals(1, result(0).getInt(0))
+    assertEquals("Alice", result(0).getString(1))
+    assertEquals(30, result(0).getInt(2))
+    assertEquals(95.5, result(0).getDouble(3), 0.01)
+
+    assertEquals(2, result(1).getInt(0))
+    assertEquals("Bob", result(1).getString(1))
+    assertEquals(25, result(1).getInt(2))
+    assertEquals(87.3, result(1).getDouble(3), 0.01)
+
+    assertEquals(3, result(2).getInt(0))
+    assertEquals("Charlie", result(2).getString(1))
+    assertEquals(35, result(2).getInt(2))
+    assertEquals(92.1, result(2).getDouble(3), 0.01)
+  }
+
+  @Test
+  def testSchemaProjection(): Unit = {
+    val tableName = "test_lance_projection"
+    val tablePath = s"$basePath/$tableName"
+
+    // Create test data with multiple columns
+    val records = Seq(
+      (1, "Alice", 30, 95.5, "Engineering"),
+      (2, "Bob", 25, 87.3, "Sales"),
+      (3, "Charlie", 35, 92.1, "Marketing")
+    )
+    val df = spark.createDataFrame(records).toDF("id", "name", "age", "score", "department")
+
+    // Write to Hudi table with Lance format
+    df.write
+      .format("hudi")
+      .option(HoodieTableConfig.BASE_FILE_FORMAT.key(), "LANCE")
+      .option(RECORDKEY_FIELD.key(), "id")
+      .option(PRECOMBINE_FIELD.key(), "age")
+      .option(TABLE_NAME.key(), tableName)
+      .option(HoodieWriteConfig.TBL_NAME.key(), tableName)
+      .option(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key(), classOf[DefaultSparkRecordMerger].getName)
+      .mode(SaveMode.Overwrite)
+      .save(tablePath)
+
+    // Read with schema projection - only select subset of columns
+    val projectedDf = spark.read
+      .format("hudi")
+      .load(tablePath)
+      .select("id", "name")  // Only read id and name
+      .orderBy("id")
+
+    val result = projectedDf.collect()
+
+    assertEquals(3, result.length, "Should read 3 records")
+    assertEquals(2, result(0).length, "Should only have 2 columns")
+
+    assertEquals(1, result(0).getInt(0))
+    assertEquals("Alice", result(0).getString(1))
+
+    assertEquals(2, result(1).getInt(0))
+    assertEquals("Bob", result(1).getString(1))
+
+    assertEquals(3, result(2).getInt(0))
+    assertEquals("Charlie", result(2).getString(1))
+  }
+}

--- a/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.3.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_3Adapter.scala
@@ -154,6 +154,13 @@ class Spark3_3Adapter extends BaseSpark3Adapter {
     Spark33OrcReader.build(vectorized, sqlConf, options, hadoopConf, dataSchema)
   }
 
+  override def createLanceFileReader(vectorized: Boolean,
+                                     sqlConf: SQLConf,
+                                     options: Map[String, String],
+                                     hadoopConf: Configuration): SparkColumnarFileReader = {
+    throw new UnsupportedOperationException("Lance format is not supported in Spark 3.3")
+  }
+
   override def stopSparkContext(jssc: JavaSparkContext, exitCode: Int): Unit = {
     jssc.stop()
   }

--- a/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.4.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_4Adapter.scala
@@ -154,6 +154,13 @@ class Spark3_4Adapter extends BaseSpark3Adapter {
     Spark34OrcReader.build(vectorized, sqlConf, options, hadoopConf, dataSchema)
   }
 
+  override def createLanceFileReader(vectorized: Boolean,
+                                     sqlConf: SQLConf,
+                                     options: Map[String, String],
+                                     hadoopConf: Configuration): SparkColumnarFileReader = {
+    throw new UnsupportedOperationException("Lance format is not supported in Spark 3.4")
+  }
+
   override def stopSparkContext(jssc: JavaSparkContext, exitCode: Int): Unit = {
     jssc.sc.stop(exitCode)
   }

--- a/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3.5.x/src/main/scala/org/apache/spark/sql/adapter/Spark3_5Adapter.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.{METADATA_COL_ATTR_KEY, RebaseDateTime}
 import org.apache.spark.sql.connector.catalog.{V1Table, V2TableWithV1Fallback}
 import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.execution.datasources.lance.SparkLanceReaderBase
 import org.apache.spark.sql.execution.datasources.orc.Spark35OrcReader
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetFilters, Spark35LegacyHoodieParquetFileFormat, Spark35ParquetReader}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -168,6 +169,13 @@ class Spark3_5Adapter extends BaseSpark3Adapter {
                                    hadoopConf: Configuration,
                                    dataSchema: StructType): SparkColumnarFileReader = {
     Spark35OrcReader.build(vectorized, sqlConf, options, hadoopConf, dataSchema)
+  }
+
+  override def createLanceFileReader(vectorized: Boolean,
+                                     sqlConf: SQLConf,
+                                     options: Map[String, String],
+                                     hadoopConf: Configuration): SparkColumnarFileReader = {
+    new SparkLanceReaderBase(vectorized)
   }
 
   override def stopSparkContext(jssc: JavaSparkContext, exitCode: Int): Unit = {

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/adapter/Spark4_0Adapter.scala
@@ -168,6 +168,13 @@ class Spark4_0Adapter extends BaseSpark4Adapter {
     Spark40OrcReader.build(vectorized, sqlConf, options, hadoopConf, dataSchema)
   }
 
+  override def createLanceFileReader(vectorized: Boolean,
+                                     sqlConf: SQLConf,
+                                     options: Map[String, String],
+                                     hadoopConf: Configuration): SparkColumnarFileReader = {
+    throw new UnsupportedOperationException("Lance format is not supported in Spark 4.0")
+  }
+
   override def stopSparkContext(jssc: JavaSparkContext, exitCode: Int): Unit = {
     jssc.sc.stop(exitCode)
   }


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

* Add an implementation of the SparkColumnarFileReader for lance which will beSparkLanceReaderBase
* Refactored the LanceIterator to be reused amongst both file reader and spark reader classes.
* Plumbing thru various FileFactory readers, and spark adapter for supporting lance
* end to end functional test TestLanceDataSource.scala to confirm read queries work


### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
