### PR TITLE
feat(index): Add VECTOR_INDEX MetadataPartitionType and configuration…

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -538,6 +538,33 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       .sinceVersion("1.0.1")
       .withDocumentation("Column for which secondary index will be built.");
 
+  public static final ConfigProperty<Boolean> VECTOR_INDEX_ENABLE_PROP = ConfigProperty
+      .key(METADATA_PREFIX + ".vector.index.enable")
+      .defaultValue(false)
+      .sinceVersion("1.4.0")
+      .withDocumentation("Enable vector index within the metadata table for ANN (approximate nearest neighbor) search.");
+
+  public static final ConfigProperty<Integer> VECTOR_INDEX_NUM_CLUSTERS = ConfigProperty
+      .key(METADATA_PREFIX + ".vector.index.num.clusters")
+      .defaultValue(256)
+      .markAdvanced()
+      .sinceVersion("1.4.0")
+      .withDocumentation("Number of clusters (centroids) to build in the vector index.");
+
+  public static final ConfigProperty<Integer> VECTOR_INDEX_FILE_GROUP_COUNT_PER_CLUSTER = ConfigProperty
+      .key(METADATA_PREFIX + ".vector.index.file.group.count.per.cluster")
+      .defaultValue(1)
+      .markAdvanced()
+      .sinceVersion("1.4.0")
+      .withDocumentation("Number of file groups per cluster in the vector index.");
+
+  public static final ConfigProperty<Long> VECTOR_INDEX_TRAINING_SAMPLE_SIZE = ConfigProperty
+      .key(METADATA_PREFIX + ".vector.index.training.sample.size")
+      .defaultValue(1_000_000L)
+      .markAdvanced()
+      .sinceVersion("1.4.0")
+      .withDocumentation("Number of vectors sampled for training the vector index clustering model.");
+
   // Config to specify metadata index to delete
   public static final ConfigProperty<String> DROP_METADATA_INDEX = ConfigProperty
       .key(METADATA_PREFIX + ".index.drop")
@@ -949,6 +976,22 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return getString(SECONDARY_INDEX_NAME);
   }
 
+  public boolean isVectorIndexEnabled() {
+    return getBooleanOrDefault(VECTOR_INDEX_ENABLE_PROP);
+  }
+
+  public int getVectorIndexNumClusters() {
+    return getInt(VECTOR_INDEX_NUM_CLUSTERS);
+  }
+
+  public int getVectorIndexFileGroupCountPerCluster() {
+    return getInt(VECTOR_INDEX_FILE_GROUP_COUNT_PER_CLUSTER);
+  }
+
+  public long getVectorIndexTrainingSampleSize() {
+    return getLong(VECTOR_INDEX_TRAINING_SAMPLE_SIZE);
+  }
+
   public String getMetadataIndexToDrop() {
     return getString(DROP_METADATA_INDEX);
   }
@@ -1291,6 +1334,11 @@ public final class HoodieMetadataConfig extends HoodieConfig {
 
     public Builder withExpressionIndexEnabled(boolean enabled) {
       metadataConfig.setValue(EXPRESSION_INDEX_ENABLE_PROP, String.valueOf(enabled));
+      return this;
+    }
+
+    public Builder withVectorIndexEnabled(boolean enabled) {
+      metadataConfig.setValue(VECTOR_INDEX_ENABLE_PROP, String.valueOf(enabled));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieIndexVersion.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieIndexVersion.java
@@ -107,6 +107,9 @@ public enum HoodieIndexVersion {
         }
         return V1;
 
+      case VECTOR_INDEX:
+        return V1;
+
       case FILES:
         return V1;
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -201,6 +201,8 @@ public class HoodieTableMetadataUtil {
   public static final String PARTITION_NAME_EXPRESSION_INDEX_PREFIX = "expr_index_";
   public static final String PARTITION_NAME_SECONDARY_INDEX = "secondary_index";
   public static final String PARTITION_NAME_SECONDARY_INDEX_PREFIX = "secondary_index_";
+  public static final String PARTITION_NAME_VECTOR_INDEX = "vector_index";
+  public static final String PARTITION_NAME_VECTOR_INDEX_PREFIX = "vector_index_";
 
   // Average size of a record saved within the record index.
   // Record index has a fixed size schema. This has been calculated based on experiments with default settings

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -82,6 +82,7 @@ import static org.apache.hudi.metadata.HoodieMetadataPayload.SECONDARY_INDEX_FIE
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_VECTOR_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.combineFileSystemMetadata;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.mergeColumnStatsRecords;
 
@@ -240,6 +241,28 @@ public enum MetadataPartitionType {
     @Override
     public SerializableBiFunction<String, Integer, Integer> getFileGroupMappingFunction(HoodieIndexVersion indexVersion) {
       return HoodieTableMetadataUtil.getSecondaryKeyToFileGroupMappingFunction(indexVersion.greaterThanOrEquals(HoodieIndexVersion.V2));
+    }
+  },
+  VECTOR_INDEX(HoodieTableMetadataUtil.PARTITION_NAME_VECTOR_INDEX_PREFIX, "vector-index-", 8) {
+    @Override
+    public boolean isMetadataPartitionEnabled(HoodieMetadataConfig metadataConfig, HoodieTableConfig tableConfig) {
+      return metadataConfig.isVectorIndexEnabled();
+    }
+
+    @Override
+    public boolean isMetadataPartitionAvailable(HoodieTableMetaClient metaClient) {
+      if (metaClient.getIndexMetadata().isPresent()) {
+        return metaClient.getIndexMetadata().get().getIndexDefinitions().values().stream()
+            .anyMatch(indexDef -> indexDef.getIndexName().startsWith(PARTITION_NAME_VECTOR_INDEX_PREFIX));
+      }
+      return false;
+    }
+
+    @Override
+    public String getPartitionPath(HoodieTableMetaClient metaClient, String indexName) {
+      return metaClient.getIndexForMetadataPartition(indexName)
+          .map(HoodieIndexDefinition::getIndexName)
+          .orElseThrow(() -> new IllegalArgumentException("Index definition is not present for index: " + indexName));
     }
   },
   PARTITION_STATS(HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS, "partition-stats-", 6) {
@@ -462,7 +485,8 @@ public enum MetadataPartitionType {
         .stream()
         .filter(type -> type != SECONDARY_INDEX
             && type != EXPRESSION_INDEX
-            && type != PARTITION_STATS)
+            && type != PARTITION_STATS
+            && type != VECTOR_INDEX)
         .toArray(MetadataPartitionType[]::new);
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
@@ -93,6 +93,10 @@ public class TestMetadataPartitionType {
         metadataConfigBuilder.enable(true).withEnableGlobalRecordLevelIndex(true).withSecondaryIndexEnabled(true).withSecondaryIndexForColumn("col1");
         expectedEnabledPartitions = tableVersionEightOrAbove ? 4 : 3;
         break;
+      case VECTOR_INDEX:
+        metadataConfigBuilder.enable(true).withVectorIndexEnabled(true);
+        expectedEnabledPartitions = tableVersionEightOrAbove ? 3 : 2;
+        break;
       case BLOOM_FILTERS:
         metadataConfigBuilder.enable(true).withMetadataIndexBloomFilter(true);
         expectedEnabledPartitions = 3;
@@ -196,6 +200,7 @@ public class TestMetadataPartitionType {
     assertEquals(MetadataPartitionType.FILES, MetadataPartitionType.fromPartitionPath("files"));
     assertEquals(MetadataPartitionType.EXPRESSION_INDEX, MetadataPartitionType.fromPartitionPath("expr_index_dummy"));
     assertEquals(MetadataPartitionType.SECONDARY_INDEX, MetadataPartitionType.fromPartitionPath("secondary_index_dummy"));
+    assertEquals(MetadataPartitionType.VECTOR_INDEX, MetadataPartitionType.fromPartitionPath("vector_index_myidx"));
     assertEquals(MetadataPartitionType.COLUMN_STATS, MetadataPartitionType.fromPartitionPath("column_stats"));
     assertEquals(MetadataPartitionType.BLOOM_FILTERS, MetadataPartitionType.fromPartitionPath("bloom_filters"));
     assertEquals(MetadataPartitionType.RECORD_INDEX, MetadataPartitionType.fromPartitionPath("record_index"));
@@ -212,6 +217,7 @@ public class TestMetadataPartitionType {
     assertEquals(5, MetadataPartitionType.RECORD_INDEX.getRecordType());
     assertEquals(6, MetadataPartitionType.PARTITION_STATS.getRecordType());
     assertEquals(7, MetadataPartitionType.SECONDARY_INDEX.getRecordType());
+    assertEquals(8, MetadataPartitionType.VECTOR_INDEX.getRecordType());
   }
 
   @ParameterizedTest
@@ -220,19 +226,30 @@ public class TestMetadataPartitionType {
     HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
     String expressionIndexName = "expr_index_dummyExpressionIndex";
     String secondaryIndexName = "secondary_index_dummySecondaryIndex";
+    String vectorIndexName = "vector_index_dummyVectorIndex";
     HoodieIndexMetadata indexMetadata = getIndexMetadata(expressionIndexName, secondaryIndexName);
     when(metaClient.getIndexMetadata()).thenReturn(Option.of(indexMetadata));
-    
-    // Mock getIndexForMetadataPartition for both index names
+
+    // Mock getIndexForMetadataPartition for all named index types
     when(metaClient.getIndexForMetadataPartition(expressionIndexName))
         .thenReturn(Option.of(indexMetadata.getIndexDefinitions().get(expressionIndexName)));
     when(metaClient.getIndexForMetadataPartition(secondaryIndexName))
         .thenReturn(Option.of(indexMetadata.getIndexDefinitions().get(secondaryIndexName)));
-    
+    HoodieIndexDefinition vectorIndexDefinition = HoodieIndexDefinition.newBuilder()
+        .withIndexName(vectorIndexName)
+        .withIndexType(MetadataPartitionType.VECTOR_INDEX.name())
+        .withIndexFunction(null)
+        .withSourceFields(Collections.singletonList("embedding"))
+        .withVersion(HoodieIndexVersion.getCurrentVersion(HoodieTableVersion.current(), vectorIndexName))
+        .build();
+    when(metaClient.getIndexForMetadataPartition(vectorIndexName)).thenReturn(Option.of(vectorIndexDefinition));
+
     if (partitionType == MetadataPartitionType.EXPRESSION_INDEX) {
       assertEquals(expressionIndexName, partitionType.getPartitionPath(metaClient, expressionIndexName));
     } else if (partitionType == MetadataPartitionType.SECONDARY_INDEX) {
       assertEquals(secondaryIndexName, partitionType.getPartitionPath(metaClient, secondaryIndexName));
+    } else if (partitionType == MetadataPartitionType.VECTOR_INDEX) {
+      assertEquals(vectorIndexName, partitionType.getPartitionPath(metaClient, vectorIndexName));
     } else {
       assertEquals(partitionType.getPartitionPath(), partitionType.getPartitionPath(metaClient, null));
     }
@@ -268,6 +285,27 @@ public class TestMetadataPartitionType {
 
     assertThrows(IllegalArgumentException.class,
         () -> partitionType.getPartitionPath(metaClient, "testIndex"));
+  }
+
+  @Test
+  public void testVectorIndexPartitionPath() {
+    String vectorIndexName = "vector_index_myidx";
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieIndexDefinition indexDefinition = HoodieIndexDefinition.newBuilder()
+        .withIndexName(vectorIndexName)
+        .withIndexType(MetadataPartitionType.VECTOR_INDEX.name())
+        .withIndexFunction(null)
+        .withSourceFields(Collections.singletonList("embedding"))
+        .withVersion(HoodieIndexVersion.getCurrentVersion(HoodieTableVersion.current(), vectorIndexName))
+        .build();
+    when(metaClient.getIndexForMetadataPartition(vectorIndexName)).thenReturn(Option.of(indexDefinition));
+
+    assertEquals(vectorIndexName, MetadataPartitionType.VECTOR_INDEX.getPartitionPath(metaClient, vectorIndexName));
+
+    // Missing index definition should throw
+    when(metaClient.getIndexForMetadataPartition(vectorIndexName)).thenReturn(Option.empty());
+    assertThrows(IllegalArgumentException.class,
+        () -> MetadataPartitionType.VECTOR_INDEX.getPartitionPath(metaClient, vectorIndexName));
   }
 
   @Test


### PR DESCRIPTION
… groundwork

Adds infrastructure scaffolding for the vector index (PR 1 of the vector index implementation board, apache/hudi#18850):

- Add PARTITION_NAME_VECTOR_INDEX / _PREFIX constants to HoodieTableMetadataUtil
- Add VECTOR_INDEX enum to MetadataPartitionType (record type 8, prefix "vector_index_", fileId prefix "vector-index-") following the same multi-instance pattern as SECONDARY_INDEX
- Add config knobs in HoodieMetadataConfig: hoodie.metadata.vector.index.enable (default false), .num.clusters (256), .file.group.count.per.cluster (1), .training.sample.size (1_000_000)
- Update TestMetadataPartitionType with partition-path derivation tests for the new index type

### Describe the issue this Pull Request addresses

<!-- Either describe the issue inline here with motivation behind the changes 
     (or) link to an issue by including `Closes #<issue-number>` for context. 
     If this PR includes changes to the storage format, public APIs,
     or has breaking changes, use `!` (e.g., feat!: ...) -->

### Summary and Changelog

<!-- Short, plain-English summary of what users gain or what changed in behavior.
     Followed by a detailed log of all the changes. Highlight if any code was copied. -->

### Impact

<!-- Describe any public API or user-facing feature change or any performance impact. -->

### Risk Level

<!-- Accepted values: none, low, medium or high. Other than `none`, explain the risk.
     If medium or high, explain what verification was done to mitigate the risks. -->

### Documentation Update

<!-- Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none".

- The config description must be updated if new configs are added or the default value of the configs are changed.
- Any new feature or user-facing change requires updating the Hudi website. Please follow the 
  [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make changes to the website. -->

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Enough context is provided in the sections above
- [ ] Adequate tests were added if applicable
