### PR TITLE
feat(utilities): add Postgres Debezium CDC transformer (ENG-44204)

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/DebeziumTransformerConfig.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/config/DebeziumTransformerConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.config;
+
+import org.apache.hudi.common.config.ConfigClassProperty;
+import org.apache.hudi.common.config.ConfigGroups;
+import org.apache.hudi.common.config.ConfigProperty;
+import org.apache.hudi.common.config.HoodieConfig;
+
+import javax.annotation.concurrent.Immutable;
+
+import static org.apache.hudi.common.util.ConfigUtils.DELTA_STREAMER_CONFIG_PREFIX;
+import static org.apache.hudi.common.util.ConfigUtils.STREAMER_CONFIG_PREFIX;
+
+/**
+ * Configurations controlling the Debezium CDC transformers (e.g.
+ * {@code PostgresDebeziumTransformer}, {@code MysqlDebeziumTransformer}).
+ */
+@Immutable
+@ConfigClassProperty(name = "Debezium Transformer Configs",
+    groupName = ConfigGroups.Names.HUDI_STREAMER,
+    subGroupName = ConfigGroups.SubGroupNames.NONE,
+    description = "Configurations controlling the Debezium CDC transformers that flatten "
+        + "Debezium change-event envelopes into Hudi rows.")
+public class DebeziumTransformerConfig extends HoodieConfig {
+
+  private static final String PREFIX = STREAMER_CONFIG_PREFIX + "transformer.debezium.";
+  private static final String OLD_PREFIX = DELTA_STREAMER_CONFIG_PREFIX + "transformer.debezium.";
+
+  public static final ConfigProperty<Boolean> ENABLE_NESTED_FIELDS = ConfigProperty
+      .key(PREFIX + "nested.fields.enable")
+      .defaultValue(false)
+      .withAlternatives(OLD_PREFIX + "nested.fields.enable")
+      .markAdvanced()
+      .sinceVersion("1.3.0")
+      .withDocumentation("When enabled, the Debezium transformer packs the CDC metadata columns "
+          + "under a single `_debezium_metadata` struct column instead of flattening them to the "
+          + "root level. The change-operation-type column and the log-position column (e.g. the "
+          + "Postgres LSN) are kept at the root level so that payload ordering keeps working. When "
+          + "this property is not set explicitly, the per-database transformer default is used "
+          + "(PostgresDebeziumTransformer defaults to true).");
+
+  public static final ConfigProperty<Boolean> SCHEMA_AS_NULLABLE = ConfigProperty
+      .key(PREFIX + "schema.nullable.enable")
+      .defaultValue(true)
+      .withAlternatives(OLD_PREFIX + "schema.nullable.enable")
+      .markAdvanced()
+      .sinceVersion("1.3.0")
+      .withDocumentation("When enabled, all columns in the transformed Debezium schema are marked "
+          + "as nullable. This keeps the output schema compatible with the nullable columns that "
+          + "Debezium change events produce.");
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/AbstractDebeziumTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/AbstractDebeziumTransformer.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.transform.debezium;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.common.util.ConfigUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.config.DebeziumTransformerConfig;
+import org.apache.hudi.utilities.transform.Transformer;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.config.HoodieErrorTableConfig.ERROR_TABLE_ENABLED;
+import static org.apache.hudi.utilities.streamer.BaseErrorTableWriter.ERROR_TABLE_CURRUPT_RECORD_COL_NAME;
+
+/**
+ * Base {@link Transformer} that flattens a Debezium change-event envelope into a Hudi row.
+ *
+ * <p>A Debezium change event is a nested record of the form
+ * {@code {op, ts_ms, before:{...}, after:{...}, source:{...}}}. This transformer:
+ * <ul>
+ *   <li>selects the {@code before} image for deletes and the {@code after} image otherwise,
+ *       and explodes it to the row's top level;</li>
+ *   <li>surfaces the common Debezium metadata columns (operation type, processing/origin
+ *       timestamps, shard) along with any database-specific metadata columns supplied by the
+ *       subclass;</li>
+ *   <li>optionally nests the metadata columns under a single {@code _debezium_metadata} struct
+ *       (see {@link DebeziumTransformerConfig#ENABLE_NESTED_FIELDS});</li>
+ *   <li>optionally preserves the error-table corrupt-record column when the error table is
+ *       enabled;</li>
+ *   <li>applies an optional database-specific post-processing step (e.g. ordering/sequence
+ *       columns, LSN defaulting);</li>
+ *   <li>normalizes column nullability (see
+ *       {@link DebeziumTransformerConfig#SCHEMA_AS_NULLABLE}).</li>
+ * </ul>
+ *
+ * <p>The flattened column names are defined in {@link DebeziumConstants}; the matching
+ * {@code DebeziumAvroPayload} implementations rely on these names for merge/ordering semantics.
+ *
+ * <p>Subclasses configure the database-specific behavior purely through the constructor; there is
+ * no abstract method to implement.
+ */
+public class AbstractDebeziumTransformer implements Transformer {
+
+  public static final String DEBEZIUM_METADATA_FIELD = "_debezium_metadata";
+  private static final String DATA_FIELD = "__data";
+
+  private static final List<Column> DEFAULT_ROOT_LEVEL_METADATA_COLUMNS = Arrays.asList(
+      new Column(DebeziumConstants.INCOMING_OP_FIELD).alias(DebeziumConstants.FLATTENED_OP_COL_NAME));
+
+  private static final List<Column> DEFAULT_NESTED_METADATA_COLUMNS = Arrays.asList(
+      new Column(DebeziumConstants.INCOMING_TS_MS_FIELD).alias(DebeziumConstants.UPSTREAM_PROCESSING_TS_COL_NAME),
+      new Column(DebeziumConstants.INCOMING_SOURCE_NAME_FIELD).alias(DebeziumConstants.FLATTENED_SHARD_NAME),
+      new Column(DebeziumConstants.INCOMING_SOURCE_TS_MS_FIELD).alias(DebeziumConstants.FLATTENED_TS_COL_NAME));
+
+  private final List<Column> typeSpecificMetadataColumns;
+  private final Option<Function<Dataset<Row>, Dataset<Row>>> postProcessingOption;
+  private final boolean nestedFieldsEnabledByDefault;
+
+  protected AbstractDebeziumTransformer(
+      List<Column> typeSpecificMetadataColumns,
+      Option<Function<Dataset<Row>, Dataset<Row>>> postProcessingOption) {
+    this(typeSpecificMetadataColumns, postProcessingOption, false);
+  }
+
+  /**
+   * @param typeSpecificMetadataColumns database-specific metadata columns (already aliased to their
+   *                                    flattened output names).
+   * @param postProcessingOption        optional post-flatten transformation applied to the result.
+   * @param nestedFieldsEnabledByDefault default used for
+   *                                     {@link DebeziumTransformerConfig#ENABLE_NESTED_FIELDS} when
+   *                                     the property is not set explicitly. Lets a subclass (e.g.
+   *                                     Postgres) opt into nested metadata by default.
+   */
+  protected AbstractDebeziumTransformer(
+      List<Column> typeSpecificMetadataColumns,
+      Option<Function<Dataset<Row>, Dataset<Row>>> postProcessingOption,
+      boolean nestedFieldsEnabledByDefault) {
+    this.typeSpecificMetadataColumns = typeSpecificMetadataColumns;
+    this.postProcessingOption = postProcessingOption;
+    this.nestedFieldsEnabledByDefault = nestedFieldsEnabledByDefault;
+  }
+
+  @Override
+  public Dataset<Row> apply(JavaSparkContext javaSparkContext, SparkSession sparkSession, Dataset<Row> rowDataset, TypedProperties props) {
+    if (rowDataset.columns().length == 0) {
+      return rowDataset;
+    }
+    // Pick selective debezium meta fields: pick the row values from before field for delete record
+    // and row values from after field for insert or update records.
+    rowDataset = rowDataset
+        .withColumn(DATA_FIELD,
+            functions.when(new Column(DebeziumConstants.INCOMING_OP_FIELD).equalTo(DebeziumConstants.DELETE_OP),
+                new Column(DebeziumConstants.INCOMING_BEFORE_FIELD))
+                .otherwise(new Column(DebeziumConstants.INCOMING_AFTER_FIELD)))
+        .drop(DebeziumConstants.INCOMING_AFTER_FIELD, DebeziumConstants.INCOMING_BEFORE_FIELD);
+
+    List<Column> allColumns = new ArrayList<>();
+    boolean enableNestedFields = isNestedFieldsEnabled(props);
+
+    // When nested fields are enabled, only _change_operation_type and root-level metadata columns should be at root level
+    if (enableNestedFields) {
+      Column lsnColumn = null;
+      List<Column> otherMetadata = new ArrayList<>();
+
+      // Extract LSN column to root level, keep other metadata nested
+      for (Column col : typeSpecificMetadataColumns) {
+        String colStr = col.toString();
+        if (colStr.contains(DebeziumConstants.FLATTENED_LSN_COL_NAME)) {
+          lsnColumn = col;
+        } else {
+          otherMetadata.add(col);
+        }
+      }
+
+      List<Column> nestedMetadataFields = new ArrayList<>();
+      nestedMetadataFields.addAll(DEFAULT_NESTED_METADATA_COLUMNS);
+      nestedMetadataFields.addAll(otherMetadata);
+
+      // Only add schema field if it exists in the source struct (not all databases have this field)
+      if (hasSchemaField(rowDataset)) {
+        nestedMetadataFields.add(new Column(DebeziumConstants.INCOMING_SOURCE_SCHEMA_FIELD).alias(DebeziumConstants.FLATTENED_SCHEMA_NAME));
+      }
+
+      rowDataset = rowDataset.withColumn(DEBEZIUM_METADATA_FIELD,
+          functions.struct(nestedMetadataFields.toArray(new Column[]{})));
+      allColumns.add(new Column(DEBEZIUM_METADATA_FIELD));
+
+      allColumns.addAll(DEFAULT_ROOT_LEVEL_METADATA_COLUMNS);
+      if (lsnColumn != null) {
+        // Add LSN column to root level
+        allColumns.add(lsnColumn);
+      }
+    } else {
+      // When nested fields are disabled, all metadata fields are at root level
+      allColumns.addAll(DEFAULT_ROOT_LEVEL_METADATA_COLUMNS);
+      allColumns.addAll(DEFAULT_NESTED_METADATA_COLUMNS);
+      allColumns.addAll(typeSpecificMetadataColumns);
+    }
+
+    allColumns.add(new Column(String.format("%s.*", DATA_FIELD)));
+
+    if (ConfigUtils.getBooleanWithAltKeys(props, ERROR_TABLE_ENABLED)) {
+      if (!Arrays.stream(rowDataset.columns()).collect(Collectors.toList())
+          .contains(ERROR_TABLE_CURRUPT_RECORD_COL_NAME)) {
+        rowDataset = rowDataset.withColumn(ERROR_TABLE_CURRUPT_RECORD_COL_NAME, functions.lit(null));
+      }
+      allColumns.add(new Column(ERROR_TABLE_CURRUPT_RECORD_COL_NAME));
+    }
+
+    Dataset<Row> flattened = rowDataset.select(allColumns.toArray(new Column[]{}));
+    Dataset<Row> debeziumDataset = postProcessingOption.map(postProcessing -> postProcessing.apply(flattened)).orElse(flattened);
+
+    if (ConfigUtils.getBooleanWithAltKeys(props, DebeziumTransformerConfig.SCHEMA_AS_NULLABLE)) {
+      return convertColumnsToNullable(sparkSession, debeziumDataset);
+    }
+
+    Set<String> nonNullableColumns = new HashSet<>();
+    for (StructField field : rowDataset.schema().fields()) {
+      if (field.dataType() instanceof StructType && DATA_FIELD.equals(field.name())) {
+        nonNullableColumns.addAll(Arrays.stream(((StructType) field.dataType()).fields())
+            .filter(dataField -> !dataField.nullable())
+            .map(StructField::name)
+            .collect(Collectors.toSet()));
+      }
+    }
+
+    // Apply correct nullability to the transformed schema
+    StructField[] updatedStructFields = Arrays.stream(debeziumDataset.schema().fields())
+        .map(field -> field.nullable() && !nonNullableColumns.contains(field.name())
+          ? new StructField(field.name(), field.dataType(), true, field.metadata())
+          : new StructField(field.name(), field.dataType(), false, field.metadata()))
+        .toArray(StructField[]::new);
+
+    return sparkSession.createDataFrame(debeziumDataset.rdd(), new StructType(updatedStructFields));
+  }
+
+  /**
+   * Resolves whether to nest the metadata columns. An explicitly set property always wins; when the
+   * property is absent the per-subclass default ({@link #nestedFieldsEnabledByDefault}) is used.
+   */
+  private boolean isNestedFieldsEnabled(TypedProperties props) {
+    return ConfigUtils.getRawValueWithAltKeys(props, DebeziumTransformerConfig.ENABLE_NESTED_FIELDS)
+        .map(value -> Boolean.parseBoolean(value.toString()))
+        .orElse(nestedFieldsEnabledByDefault);
+  }
+
+  /**
+   * Rebuilds the dataset with every column marked nullable.
+   */
+  private static Dataset<Row> convertColumnsToNullable(SparkSession sparkSession, Dataset<Row> dataset) {
+    StructField[] modifiedStructFields = Arrays.stream(dataset.schema().fields())
+        .map(field -> new StructField(field.name(), field.dataType(), true, field.metadata()))
+        .toArray(StructField[]::new);
+    return sparkSession.createDataFrame(dataset.rdd(), new StructType(modifiedStructFields));
+  }
+
+  private static boolean hasSchemaField(Dataset<Row> rowDataset) {
+    return Arrays.stream(rowDataset.schema().fields())
+        .filter(field -> DebeziumConstants.INCOMING_SOURCE_FIELD.equals(field.name()) && field.dataType() instanceof StructType)
+        .findFirst()
+        .map(field -> {
+          StructType sourceType = (StructType) field.dataType();
+          return Arrays.stream(sourceType.fields())
+              .anyMatch(sourceField -> "schema".equals(sourceField.name()));
+        })
+        .orElse(false);
+  }
+}

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/PostgresDebeziumTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/debezium/PostgresDebeziumTransformer.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.utilities.transform.debezium;
+
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.common.util.Option;
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.spark.sql.functions.expr;
+import static org.apache.spark.sql.functions.when;
+
+/**
+ * {@link AbstractDebeziumTransformer} for Postgres Debezium change events.
+ *
+ * <p>Surfaces the Postgres-specific source metadata ({@code txId}, {@code lsn}, {@code xmin}) as the
+ * flattened {@code _event_tx_id}, {@code _event_lsn} and {@code _event_xmin} columns. The
+ * {@code _event_lsn} column is the ordering field used by {@code PostgresDebeziumAvroPayload}.
+ *
+ * <p>Post-processing defaults a null {@code _event_lsn} to {@code 0} for snapshot records, since the
+ * LSN is not populated for rows produced by Debezium incremental snapshots
+ * (see <a href="https://debezium.io/blog/2021/10/07/incremental-snapshots/">incremental snapshots</a>).
+ *
+ * <p>Nested metadata is enabled by default for Postgres (the {@code _event_lsn} and operation-type
+ * columns stay at the root level so payload ordering keeps working); set
+ * {@code hoodie.streamer.transformer.debezium.nested.fields.enable=false} to flatten all metadata.
+ */
+public class PostgresDebeziumTransformer extends AbstractDebeziumTransformer {
+
+  // Snapshot operation type emitted by Debezium ("read").
+  private static final String SNAPSHOT_OP = "r";
+
+  private static final List<Column> POSTGRES_METADATA = Arrays.asList(
+      new Column(DebeziumConstants.INCOMING_SOURCE_TXID_FIELD).alias(DebeziumConstants.FLATTENED_TX_ID_COL_NAME),
+      new Column(DebeziumConstants.INCOMING_SOURCE_LSN_FIELD).alias(DebeziumConstants.FLATTENED_LSN_COL_NAME),
+      new Column(DebeziumConstants.INCOMING_SOURCE_XMIN_FIELD).alias(DebeziumConstants.FLATTENED_XMIN_COL_NAME));
+
+  public PostgresDebeziumTransformer() {
+    super(POSTGRES_METADATA, Option.of(PostgresDebeziumTransformer::useDefaultValuesForLsnIfNull), true);
+  }
+
+  /**
+   * Defaults a null {@code _event_lsn} to {@code 0} for snapshot records. The LSN is null when a
+   * table is added via a Debezium incremental snapshot; leaving it null would break LSN-based
+   * ordering in the payload.
+   *
+   * @param dataset flattened Postgres Debezium dataset.
+   * @return dataset where null {@code _event_lsn} values on snapshot rows are replaced with 0.
+   */
+  private static Dataset<Row> useDefaultValuesForLsnIfNull(Dataset<Row> dataset) {
+    if (!Arrays.asList(dataset.columns()).contains(DebeziumConstants.FLATTENED_LSN_COL_NAME)) {
+      return dataset;
+    }
+
+    return dataset.withColumn(DebeziumConstants.FLATTENED_LSN_COL_NAME, when(
+        dataset.col(DebeziumConstants.FLATTENED_OP_COL_NAME).equalTo(SNAPSHOT_OP),
+        expr(String.format("coalesce(%s, cast(0 as long))", DebeziumConstants.FLATTENED_LSN_COL_NAME))
+    ).otherwise(dataset.col(DebeziumConstants.FLATTENED_LSN_COL_NAME)));
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/DebeziumTransformerTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/DebeziumTransformerTestBase.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.transform.debezium;
+
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.apache.hudi.testutils.HoodieClientTestUtils.getSparkConfForTest;
+
+/**
+ * Lightweight Spark test base for the Debezium transformer tests. Spins up a single local
+ * SparkSession for the test class and parses inline JSON fixtures into {@link Dataset}s that mimic
+ * Debezium change-event envelopes.
+ */
+public abstract class DebeziumTransformerTestBase {
+
+  protected static SparkSession spark;
+  protected static JavaSparkContext jsc;
+
+  @BeforeAll
+  static void setUpSpark() throws IOException {
+    spark = SparkSession.builder()
+        .config(getSparkConfForTest(DebeziumTransformerTestBase.class.getName()))
+        .getOrCreate();
+    jsc = JavaSparkContext.fromSparkContext(spark.sparkContext());
+  }
+
+  @AfterAll
+  static void tearDownSpark() {
+    if (spark != null) {
+      spark.close();
+      spark = null;
+      jsc = null;
+    }
+  }
+
+  /**
+   * Parses each argument as a single JSON document into a {@link Dataset}. Passing several
+   * envelopes together lets Spark infer struct types for {@code before}/{@code after} even when an
+   * individual envelope leaves one of them null (inserts have no {@code before}, deletes have no
+   * {@code after}).
+   */
+  protected Dataset<Row> jsonToDataset(String... jsonDocs) {
+    return spark.read().json(jsc.parallelize(Arrays.asList(jsonDocs), 1));
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestAbstractDebeziumTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestAbstractDebeziumTransformer.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.transform.debezium;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.config.DebeziumTransformerConfig;
+
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.apache.hudi.utilities.transform.debezium.AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the database-agnostic flattening behavior of {@link AbstractDebeziumTransformer}.
+ */
+class TestAbstractDebeziumTransformer extends DebeziumTransformerTestBase {
+
+  // One insert (op=c), one update (op=u), one delete (op=d). before/after differ so the test can
+  // prove which image is selected. The delete carries values only in `before` (after is null).
+  private static final String INSERT_EVENT =
+      "{\"op\":\"c\",\"ts_ms\":1700000000500,"
+          + "\"before\":null,"
+          + "\"after\":{\"id\":1,\"name\":\"Alice\",\"email\":\"alice@x.com\"},"
+          + "\"source\":{\"name\":\"pgdb\",\"ts_ms\":1700000000000,\"schema\":\"public\"}}";
+  private static final String UPDATE_EVENT =
+      "{\"op\":\"u\",\"ts_ms\":1700000001500,"
+          + "\"before\":{\"id\":2,\"name\":\"Bob\",\"email\":\"old@x.com\"},"
+          + "\"after\":{\"id\":2,\"name\":\"Bob\",\"email\":\"new@x.com\"},"
+          + "\"source\":{\"name\":\"pgdb\",\"ts_ms\":1700000001000,\"schema\":\"public\"}}";
+  private static final String DELETE_EVENT =
+      "{\"op\":\"d\",\"ts_ms\":1700000002500,"
+          + "\"before\":{\"id\":3,\"name\":\"Carol\",\"email\":\"carol@x.com\"},"
+          + "\"after\":null,"
+          + "\"source\":{\"name\":\"pgdb\",\"ts_ms\":1700000002000,\"schema\":\"public\"}}";
+
+  @Test
+  void testAfterUsedForInsertUpdate_beforeUsedForDelete() {
+    Dataset<Row> input = jsonToDataset(INSERT_EVENT, UPDATE_EVENT, DELETE_EVENT);
+    Dataset<Row> result = new TestableDebeziumTransformer().apply(jsc, spark, input, new TypedProperties());
+
+    List<String> columns = Arrays.asList(result.columns());
+    assertTrue(columns.containsAll(Arrays.asList("id", "name", "email")), "data columns lifted to root");
+    assertFalse(columns.contains(DebeziumConstants.INCOMING_AFTER_FIELD), "after dropped");
+    assertFalse(columns.contains(DebeziumConstants.INCOMING_BEFORE_FIELD), "before dropped");
+
+    List<Row> rows = result.orderBy("id").collectAsList();
+    assertEquals(3, rows.size());
+
+    // insert -> taken from `after`
+    assertEquals("c", rows.get(0).getAs(DebeziumConstants.FLATTENED_OP_COL_NAME));
+    assertEquals("Alice", rows.get(0).getAs("name"));
+    assertEquals("alice@x.com", rows.get(0).getAs("email"));
+
+    // update -> taken from `after` (the NEW email, not the before/old one)
+    assertEquals("u", rows.get(1).getAs(DebeziumConstants.FLATTENED_OP_COL_NAME));
+    assertEquals("new@x.com", rows.get(1).getAs("email"));
+
+    // delete -> taken from `before` (after is null, but we keep the key/row)
+    assertEquals("d", rows.get(2).getAs(DebeziumConstants.FLATTENED_OP_COL_NAME));
+    assertEquals("Carol", rows.get(2).getAs("name"));
+    assertEquals("carol@x.com", rows.get(2).getAs("email"));
+  }
+
+  @Test
+  void testDefaultMetadataColumnsAtRootWhenFlat() {
+    Dataset<Row> input = jsonToDataset(INSERT_EVENT, UPDATE_EVENT, DELETE_EVENT);
+    Dataset<Row> result = new TestableDebeziumTransformer().apply(jsc, spark, input, new TypedProperties());
+
+    List<String> columns = Arrays.asList(result.columns());
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_OP_COL_NAME));
+    assertTrue(columns.contains(DebeziumConstants.UPSTREAM_PROCESSING_TS_COL_NAME));
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_SHARD_NAME));
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_TS_COL_NAME));
+    assertFalse(columns.contains(DEBEZIUM_METADATA_FIELD), "no nested struct when flat");
+
+    // shard name comes from source.name
+    assertEquals("pgdb", result.orderBy("id").collectAsList().get(0).getAs(DebeziumConstants.FLATTENED_SHARD_NAME));
+  }
+
+  @Test
+  void testNestedModeGroupsMetadataButKeepsOpAndLsnAtRoot() {
+    // Supply an LSN-named metadata column so the LSN-to-root branch is exercised.
+    Column lsnColumn = new Column(DebeziumConstants.INCOMING_SOURCE_NAME_FIELD).alias(DebeziumConstants.FLATTENED_LSN_COL_NAME);
+    TestableDebeziumTransformer transformer =
+        new TestableDebeziumTransformer(Collections.singletonList(lsnColumn), Option.empty(), false);
+
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "true");
+
+    Dataset<Row> result = transformer.apply(jsc, spark, jsonToDataset(INSERT_EVENT, UPDATE_EVENT, DELETE_EVENT), props);
+    List<String> columns = Arrays.asList(result.columns());
+
+    assertTrue(columns.contains(DEBEZIUM_METADATA_FIELD), "metadata grouped under a struct");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_OP_COL_NAME), "op stays at root");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_LSN_COL_NAME), "LSN stays at root");
+    assertFalse(columns.contains(DebeziumConstants.FLATTENED_SHARD_NAME), "shard moved into the nested struct");
+
+    Row metadata = result.first().getAs(DEBEZIUM_METADATA_FIELD);
+    List<String> nested = Arrays.asList(metadata.schema().fieldNames());
+    assertTrue(nested.contains(DebeziumConstants.FLATTENED_SHARD_NAME));
+    assertTrue(nested.contains(DebeziumConstants.FLATTENED_SCHEMA_NAME), "source.schema present -> nested schema col added");
+    assertFalse(nested.contains(DebeziumConstants.FLATTENED_LSN_COL_NAME), "LSN is at root, not nested");
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testNestedDefaultIsUsedWhenPropertyAbsent(boolean subclassDefault) {
+    TestableDebeziumTransformer transformer =
+        new TestableDebeziumTransformer(Collections.emptyList(), Option.empty(), subclassDefault);
+
+    // property NOT set -> subclass default decides
+    Dataset<Row> result = transformer.apply(jsc, spark, jsonToDataset(INSERT_EVENT, UPDATE_EVENT, DELETE_EVENT), new TypedProperties());
+    assertEquals(subclassDefault, Arrays.asList(result.columns()).contains(DEBEZIUM_METADATA_FIELD));
+  }
+
+  @Test
+  void testExplicitPropertyOverridesSubclassDefault() {
+    // subclass defaults to nested=true, but an explicit false must win
+    TestableDebeziumTransformer transformer =
+        new TestableDebeziumTransformer(Collections.emptyList(), Option.empty(), true);
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "false");
+
+    Dataset<Row> result = transformer.apply(jsc, spark, jsonToDataset(INSERT_EVENT, UPDATE_EVENT, DELETE_EVENT), props);
+    assertFalse(Arrays.asList(result.columns()).contains(DEBEZIUM_METADATA_FIELD));
+  }
+
+  @Test
+  void testPostProcessingHookIsApplied() {
+    Function<Dataset<Row>, Dataset<Row>> addColumn =
+        ds -> ds.withColumn("processed", org.apache.spark.sql.functions.lit(true));
+    TestableDebeziumTransformer transformer =
+        new TestableDebeziumTransformer(Collections.emptyList(), Option.of(addColumn), false);
+
+    Dataset<Row> result = transformer.apply(jsc, spark, jsonToDataset(INSERT_EVENT, UPDATE_EVENT, DELETE_EVENT), new TypedProperties());
+    assertTrue(Arrays.asList(result.columns()).contains("processed"));
+    assertTrue(result.collectAsList().stream().allMatch(r -> Boolean.TRUE.equals(r.getAs("processed"))));
+  }
+
+  @Test
+  void testEmptyDatasetIsReturnedUnchanged() {
+    Dataset<Row> empty = spark.emptyDataFrame();
+    Dataset<Row> result = new TestableDebeziumTransformer().apply(jsc, spark, empty, new TypedProperties());
+    assertEquals(0, result.columns().length);
+  }
+
+  /** Minimal concrete subclass to exercise the otherwise database-agnostic base. */
+  private static class TestableDebeziumTransformer extends AbstractDebeziumTransformer {
+    TestableDebeziumTransformer() {
+      super(Collections.emptyList(), Option.empty());
+    }
+
+    TestableDebeziumTransformer(List<Column> typeSpecificMetadataColumns,
+                                Option<Function<Dataset<Row>, Dataset<Row>>> postProcessingOption,
+                                boolean nestedFieldsEnabledByDefault) {
+      super(typeSpecificMetadataColumns, postProcessingOption, nestedFieldsEnabledByDefault);
+    }
+  }
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestPostgresDebeziumTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/debezium/TestPostgresDebeziumTransformer.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.utilities.transform.debezium;
+
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.model.debezium.DebeziumConstants;
+import org.apache.hudi.utilities.config.DebeziumTransformerConfig;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the Postgres-specific behavior of {@link PostgresDebeziumTransformer}: the surfaced source
+ * metadata columns, the nested-by-default layout, and the snapshot LSN defaulting.
+ */
+class TestPostgresDebeziumTransformer extends DebeziumTransformerTestBase {
+
+  // A Postgres source struct carries txId/lsn/xmin/schema in addition to name/ts_ms.
+  // before is populated (same shape as after) so Spark infers it as a struct; these tests exercise
+  // inserts/snapshots (op c/r), which take `after` regardless of before's contents.
+  private static String pgEvent(String op, long id, long lsn, boolean nullLsn) {
+    String row = "{\"id\":" + id + ",\"name\":\"row" + id + "\",\"email\":\"e" + id + "@x.com\"}";
+    return "{\"op\":\"" + op + "\",\"ts_ms\":1700000000500,"
+        + "\"before\":" + row + ","
+        + "\"after\":" + row + ","
+        + "\"source\":{\"name\":\"pgdb\",\"ts_ms\":1700000000000,\"schema\":\"public\","
+        + "\"txId\":" + (500 + id) + ",\"lsn\":" + (nullLsn ? "null" : lsn) + ",\"xmin\":" + (9000 + id) + "}}";
+  }
+
+  @Test
+  void testPostgresMetadataColumnsAreSurfaced() {
+    TypedProperties props = new TypedProperties();
+    // force flat so all metadata columns sit at root and are easy to assert
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "false");
+
+    Dataset<Row> result = new PostgresDebeziumTransformer()
+        .apply(jsc, spark, jsonToDataset(pgEvent("c", 1, 1001, false)), props);
+
+    List<String> columns = Arrays.asList(result.columns());
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_TX_ID_COL_NAME), "_event_tx_id present");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_LSN_COL_NAME), "_event_lsn present");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_XMIN_COL_NAME), "_event_xmin present");
+
+    Row row = result.first();
+    long lsn = row.<Long>getAs(DebeziumConstants.FLATTENED_LSN_COL_NAME);
+    long txId = row.<Long>getAs(DebeziumConstants.FLATTENED_TX_ID_COL_NAME);
+    assertEquals(1001L, lsn);
+    assertEquals(501L, txId);
+  }
+
+  @Test
+  void testPostgresDefaultsToNestedMetadata() {
+    // No nested property set -> Postgres should nest by default, with op + LSN kept at root.
+    Dataset<Row> result = new PostgresDebeziumTransformer()
+        .apply(jsc, spark, jsonToDataset(pgEvent("c", 1, 1001, false)), new TypedProperties());
+
+    List<String> columns = Arrays.asList(result.columns());
+    assertTrue(columns.contains(AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD), "nested by default for Postgres");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_OP_COL_NAME), "op at root");
+    assertTrue(columns.contains(DebeziumConstants.FLATTENED_LSN_COL_NAME), "LSN at root (payload ordering field)");
+    assertFalse(columns.contains(DebeziumConstants.FLATTENED_TX_ID_COL_NAME), "tx id is nested, not at root");
+
+    Row metadata = result.first().getAs(AbstractDebeziumTransformer.DEBEZIUM_METADATA_FIELD);
+    assertTrue(Arrays.asList(metadata.schema().fieldNames()).contains(DebeziumConstants.FLATTENED_TX_ID_COL_NAME));
+  }
+
+  @Test
+  void testNullLsnDefaultedToZeroForSnapshotRows() {
+    // Snapshot rows (op = r) from incremental snapshots can have a null LSN; it must become 0
+    // so the payload's "higher LSN wins" ordering does not choke on null.
+    Dataset<Row> input = jsonToDataset(
+        pgEvent("r", 1, 0, true),    // snapshot, null lsn -> expect 0
+        pgEvent("r", 2, 2002, false) // snapshot, real lsn -> unchanged
+    );
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "false");
+
+    Dataset<Row> result = new PostgresDebeziumTransformer().apply(jsc, spark, input, props);
+    List<Row> rows = result.orderBy("id").collectAsList();
+
+    long defaultedLsn = rows.get(0).<Long>getAs(DebeziumConstants.FLATTENED_LSN_COL_NAME);
+    long preservedLsn = rows.get(1).<Long>getAs(DebeziumConstants.FLATTENED_LSN_COL_NAME);
+    assertEquals(0L, defaultedLsn, "null snapshot LSN defaulted to 0");
+    assertEquals(2002L, preservedLsn, "real LSN preserved");
+  }
+
+  @Test
+  void testNullLsnNotDefaultedForNonSnapshotRows() {
+    // For a real change event (op != r) a null LSN is left as null (only snapshots are defaulted).
+    Dataset<Row> input = jsonToDataset(pgEvent("c", 1, 0, true));
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DebeziumTransformerConfig.ENABLE_NESTED_FIELDS.key(), "false");
+
+    Dataset<Row> result = new PostgresDebeziumTransformer().apply(jsc, spark, input, props);
+    assertNull(result.first().getAs(DebeziumConstants.FLATTENED_LSN_COL_NAME));
+  }
+}


### PR DESCRIPTION
### Describe the issue this Pull Request addresses

First PR upstreaming onehouse's Debezium CDC transformers (tracking: ENG-44204). Today OSS Hudi flattens Debezium change events inside the *source* (`PostgresDebeziumSource.processDataset()`), which welds the flattening to a Kafka + schema-registry source. This extracts the flattening into a standalone, source-agnostic `Transformer`, so any source emitting the raw Debezium envelope (Kafka, S3/file CDC logs, …) can use it.

### Summary and Changelog

Adds the foundation plus the Postgres implementation in `hudi-utilities`:
- `transform/debezium/AbstractDebeziumTransformer`: selects `before` (deletes) / `after` (insert/update), surfaces the Debezium metadata columns, supports an optional nested `_debezium_metadata` layout, passes the error-table corrupt-record column through, and normalizes nullability.
- `transform/debezium/PostgresDebeziumTransformer`: surfaces `txId`/`lsn`/`xmin`, defaults a null `_event_lsn` to 0 for snapshot rows, and nests metadata by default.
- `config/DebeziumTransformerConfig`: `hoodie.streamer.transformer.debezium.{nested.fields,schema.nullable}.enable`.

The flattened output column names match `DebeziumConstants`, so the existing `PostgresDebeziumAvroPayload` (orders by `_event_lsn`, deletes via `_change_operation_type=d`) keeps working unchanged. No code was copied verbatim; logic was reworked from the onehouse internal implementation.

### Impact

New opt-in transformer + two new advanced configs. No change to existing sources or payloads. Users compose `--transformer-class …PostgresDebeziumTransformer` with the existing Postgres Debezium payload.

### Risk Level

low — additive only; existing Debezium source/payload paths are untouched. Verified with 12 unit tests covering image selection, flat vs nested layout, per-subclass nested default + override, and snapshot LSN defaulting; checkstyle and RAT clean.

### Documentation Update

Two new configs are documented via `withDocumentation()` in `DebeziumTransformerConfig`. Website/user-guide updates for the transformer-based CDC flow will follow in a later PR in this series.

### Contributor's checklist

- [x] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [x] Enough context is provided in the sections above
- [x] Adequate tests were added if applicable